### PR TITLE
Message1 generics

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -1,5 +1,5 @@
 name:                proto3-suite
-version:             0.1.0.0
+version:             0.2.0
 synopsis:            A low level library for writing out data in the Protocol Buffers wire format
 license:             Apache-2.0
 author:              Awake Networks
@@ -24,7 +24,7 @@ library
   other-modules:       Proto3.Suite.DotProto.Internal
                        Proto3.Suite.DotProto.Generate.Swagger
                        Proto3.Suite.JSONPB.Class
-  build-depends:       aeson >= 1.2.4.0 && < 1.3,
+  build-depends:       aeson >= 1.3 && < 1.4,
                        aeson-pretty,
                        attoparsec >= 0.13.0.1,
                        base >=4.8 && <5.0,

--- a/src/Proto3/Suite.hs
+++ b/src/Proto3/Suite.hs
@@ -30,6 +30,7 @@ module Proto3.Suite
 
   -- * Documentation
   , message
+  , message1
   , enum
   , RenderingOptions(..)
   , Named(..)

--- a/src/Proto3/Suite/Class.hs
+++ b/src/Proto3/Suite/Class.hs
@@ -426,6 +426,12 @@ instance MessageField1 f => GenericMessage1 (Rec1 f) where
   genericLiftDecodeMessage decodeMessage fieldNumber = fmap Rec1 $ at (liftDecodeMessageField decodeMessage) fieldNumber
   genericLiftDotProto dotProto (_ :: Proxy (Rec1 f a)) = [ DotProtoMessageField $ liftProtoType dotProto (Proxy @(f a)) ]
 
+instance GenericMessage1 Par1 where
+  type GenericFieldCount1 Par1 = 1
+  genericLiftEncodeMessage encodeMessage fieldNumber (Par1 x) = encodeMessage fieldNumber x
+  genericLiftDecodeMessage decodeMessage fieldNumber = fmap Par1 $ decodeMessage fieldNumber
+  genericLiftDotProto dotProto (_ :: Proxy (Par1 a)) = [ DotProtoMessageField $ messageField (Prim (Named (Single (nameOf (Proxy @a))))) Nothing ]
+
 
 class MessageField1 f where
   liftEncodeMessageField :: (FieldNumber -> a -> Encode.MessageBuilder) -> FieldNumber -> f a -> Encode.MessageBuilder
@@ -705,12 +711,6 @@ instance (Selector s, GenericMessage1 f) => GenericMessage1 (M1 S s f) where
       newName = guard (not (null name)) $> Single name
         where
           name = selName (undefined :: S1 s f ())
-
-instance GenericMessage1 Par1 where
-  type GenericFieldCount1 Par1 = 1
-  genericLiftEncodeMessage encodeMessage fieldNumber (Par1 x) = encodeMessage fieldNumber x
-  genericLiftDecodeMessage decodeMessage fieldNumber = fmap Par1 $ decodeMessage fieldNumber
-  genericLiftDotProto dotProto _ = dotProto Proxy
 
 instance (KnownNat (GenericFieldCount1 f), GenericMessage1 f, GenericMessage1 g) => GenericMessage1 (f :*: g) where
   type GenericFieldCount1 (f :*: g) = GenericFieldCount1 f + GenericFieldCount1 g

--- a/src/Proto3/Suite/Class.hs
+++ b/src/Proto3/Suite/Class.hs
@@ -724,7 +724,7 @@ instance (KnownNat (GenericFieldCount1 f), GenericMessage1 f, GenericMessage1 g)
   genericLiftDecodeMessage decodeMessage num = liftM2 (:*:) (genericLiftDecodeMessage decodeMessage num) (genericLiftDecodeMessage decodeMessage num2)
     where num2 = FieldNumber $ getFieldNumber num + offset
           offset = fromIntegral $ natVal (Proxy @(GenericFieldCount1 f))
-  genericLiftDotProto dotProto _ = genericLiftDotProto dotProto (Proxy @f) <> adjust (genericLiftDotProto dotProto (Proxy @g))
+  genericLiftDotProto dotProto (_ :: Proxy ((f :*: g) a)) = genericLiftDotProto dotProto (Proxy @(f a)) <> adjust (genericLiftDotProto dotProto (Proxy @(g a)))
     where
       offset = fromIntegral $ natVal (Proxy @(GenericFieldCount1 f))
       adjust = map adjustPart

--- a/src/Proto3/Suite/Class.hs
+++ b/src/Proto3/Suite/Class.hs
@@ -716,12 +716,6 @@ instance GenericMessage1 Par1 where
   genericLiftDecodeMessage decodeMessage fieldNumber = fmap Par1 $ decodeMessage fieldNumber
   genericLiftDotProto dotProto _ = dotProto Proxy
 
-instance (KnownNat (GenericFieldCount1 f), GenericMessage1 f) => GenericMessage1 (Rec1 f) where
-  type GenericFieldCount1 (Rec1 f) = GenericFieldCount1 f
-  genericLiftEncodeMessage encodeMessage fieldNumber (Rec1 x) = genericLiftEncodeMessage encodeMessage fieldNumber x
-  genericLiftDecodeMessage decodeMessage fieldNumber = fmap Rec1 $ genericLiftDecodeMessage decodeMessage fieldNumber
-  genericLiftDotProto dotProto _ = dotProto Proxy
-
 instance (KnownNat (GenericFieldCount1 f), GenericMessage1 f, GenericMessage1 g) => GenericMessage1 (f :*: g) where
   type GenericFieldCount1 (f :*: g) = GenericFieldCount1 f + GenericFieldCount1 g
   genericLiftEncodeMessage encodeMessage num (x :*: y) = genericLiftEncodeMessage  encodeMessage num x <> genericLiftEncodeMessage encodeMessage (FieldNumber (getFieldNumber num + offset)) y

--- a/src/Proto3/Suite/Class.hs
+++ b/src/Proto3/Suite/Class.hs
@@ -623,34 +623,84 @@ class Message1 f where
   default liftEncodeMessage :: (Generic1 f, GenericMessage1 (Rep1 f)) => (FieldNumber -> a -> Encode.MessageBuilder) -> FieldNumber -> f a -> Encode.MessageBuilder
   liftEncodeMessage encodeMessage fieldNumber = genericLiftEncodeMessage encodeMessage fieldNumber . from1
 
-class GenericMessage1 f where
-  type GenericFieldCount1 f :: Nat
-  genericLiftEncodeMessage :: (FieldNumber -> a -> Encode.MessageBuilder) -> FieldNumber -> f a -> Encode.MessageBuilder
+  liftDecodeMessage :: (FieldNumber -> Parser RawMessage a) -> FieldNumber -> Parser RawMessage (f a)
+  default liftDecodeMessage :: (Generic1 f, GenericMessage1 (Rep1 f)) => (FieldNumber -> Parser RawMessage a) -> FieldNumber -> Parser RawMessage (f a)
+  liftDecodeMessage decodeMessage fieldNumber = fmap to1 $ genericLiftDecodeMessage decodeMessage fieldNumber
 
-instance GenericMessage1 U1 where
-  type GenericFieldCount1 U1 = 0
-  genericLiftEncodeMessage _ _ _ = mempty
-
-instance GenericMessage1 f => GenericMessage1 (M1 D c f) where
-  type GenericFieldCount1 (M1 D c f) = GenericFieldCount1 f
-  genericLiftEncodeMessage encodeMessage fieldNumber (M1 x) = genericLiftEncodeMessage encodeMessage fieldNumber x
-
-instance GenericMessage1 f => GenericMessage1 (M1 C c f) where
-  type GenericFieldCount1 (M1 C c f) = GenericFieldCount1 f
-  genericLiftEncodeMessage encodeMessage fieldNumber (M1 x) = genericLiftEncodeMessage encodeMessage fieldNumber x
-
-instance GenericMessage1 Par1 where
-  type GenericFieldCount1 Par1 = 1
-  genericLiftEncodeMessage encodeMessage fieldNumber (Par1 x) = encodeMessage fieldNumber x
-
-  -- genericDecodeMessage _ = return U1
-  -- genericDotProto _      = mempty
 
 -- | Generate metadata for a message type.
 message :: (Message a, Named a) => Proxy a -> DotProtoDefinition
 message pr = DotProtoMessage (Single $ nameOf pr) $ DotProtoMessageField <$> (dotProto pr)
 
 -- * Generic Instances
+
+class GenericMessage1 f where
+  type GenericFieldCount1 f :: Nat
+  genericLiftEncodeMessage :: (FieldNumber -> a -> Encode.MessageBuilder) -> FieldNumber -> f a -> Encode.MessageBuilder
+  genericLiftDecodeMessage :: (FieldNumber -> Parser RawMessage a) -> FieldNumber -> Parser RawMessage (f a)
+
+instance GenericMessage1 U1 where
+  type GenericFieldCount1 U1 = 0
+  genericLiftEncodeMessage _ _ _ = mempty
+  genericLiftDecodeMessage _ _ = pure U1
+  -- genericDecodeMessage _ = return U1
+  -- genericDotProto _      = mempty
+
+instance GenericMessage1 f => GenericMessage1 (M1 D c f) where
+  type GenericFieldCount1 (M1 D c f) = GenericFieldCount1 f
+  genericLiftEncodeMessage encodeMessage fieldNumber (M1 x) = genericLiftEncodeMessage encodeMessage fieldNumber x
+  genericLiftDecodeMessage decodeMessage fieldNumber = fmap M1 $ genericLiftDecodeMessage decodeMessage fieldNumber
+  -- genericDecodeMessage _ _ _ =  _
+  -- genericDotProto _ _ _      = _
+
+instance GenericMessage1 f => GenericMessage1 (M1 C c f) where
+  type GenericFieldCount1 (M1 C c f) = GenericFieldCount1 f
+  genericLiftEncodeMessage encodeMessage fieldNumber (M1 x) = genericLiftEncodeMessage encodeMessage fieldNumber x
+  genericLiftDecodeMessage decodeMessage fieldNumber = fmap M1 $ genericLiftDecodeMessage decodeMessage fieldNumber
+  -- genericDecodeMessage _ _ _ =  _
+  -- genericDotProto _ _ _      = _
+
+instance (Selector s, GenericMessage1 f) => GenericMessage1 (M1 S s f) where
+  type GenericFieldCount1 (M1 S s f) = GenericFieldCount1 f
+  genericLiftEncodeMessage encodeMessage fieldNumber (M1 x) = genericLiftEncodeMessage encodeMessage fieldNumber x
+  genericLiftDecodeMessage decodeMessage fieldNumber = fmap M1 $ genericLiftDecodeMessage decodeMessage fieldNumber
+  -- genericDecodeMessage num = fmap M1 $ genericDecodeMessage num
+  -- genericDotProto _ = map applyName $ genericDotProto (Proxy @f)
+  --   where
+  --     applyName :: DotProtoField -> DotProtoField
+  --     applyName mp = mp { dotProtoFieldName = fromMaybe Anonymous newName} -- [issue] this probably doesn't match the intended name generating semantics
+  --
+  --     newName :: Maybe DotProtoIdentifier
+  --     newName = guard (not (null name)) $> Single name
+  --       where
+  --         name = selName (undefined :: S1 s f ())
+
+instance GenericMessage1 Par1 where
+  type GenericFieldCount1 Par1 = 1
+  genericLiftEncodeMessage encodeMessage fieldNumber (Par1 x) = encodeMessage fieldNumber x
+  genericLiftDecodeMessage decodeMessage fieldNumber = fmap Par1 $ decodeMessage fieldNumber
+  -- genericDecodeMessage _ _ _ =  _
+  -- genericDotProto _ _ _      = _
+
+instance (KnownNat (GenericFieldCount1 f), GenericMessage1 f, GenericMessage1 g) => GenericMessage1 (f :*: g) where
+  type GenericFieldCount1 (f :*: g) = GenericFieldCount1 f + GenericFieldCount1 g
+  genericLiftEncodeMessage encodeMessage num (x :*: y) = genericLiftEncodeMessage  encodeMessage num x <> genericLiftEncodeMessage encodeMessage (FieldNumber (getFieldNumber num + offset)) y
+    where
+      offset = fromIntegral $ natVal (Proxy @(GenericFieldCount1 f))
+  genericLiftDecodeMessage decodeMessage num = liftM2 (:*:) (genericLiftDecodeMessage decodeMessage num) (genericLiftDecodeMessage decodeMessage num2)
+    where num2 = FieldNumber $ getFieldNumber num + offset
+          offset = fromIntegral $ natVal (Proxy @(GenericFieldCount1 f))
+  -- genericDotProto _ = genericDotProto (Proxy @f) <> adjust (genericDotProto (Proxy @g))
+    -- where
+    --   offset = fromIntegral $ natVal (Proxy @(GenericFieldCount f))
+    --   adjust = map adjustPart
+      -- adjustPart part = part { dotProtoFieldNumber = (FieldNumber . (offset +) . getFieldNumber . dotProtoFieldNumber) part }
+
+instance MessageField c => GenericMessage1 (K1 i c) where
+  type GenericFieldCount1 (K1 i c) = 1
+  genericLiftEncodeMessage encodeMessage num (K1 x) = encodeMessageField num x
+  genericLiftDecodeMessage decodeMessage num = fmap K1 (at decodeMessageField num)
+  -- genericDotProto _ = [protoType (Proxy @c)]
 
 class GenericMessage (f :: * -> *) where
   type GenericFieldCount f :: Nat

--- a/src/Proto3/Suite/Class.hs
+++ b/src/Proto3/Suite/Class.hs
@@ -688,6 +688,12 @@ instance GenericMessage1 Par1 where
   genericLiftDecodeMessage decodeMessage fieldNumber = fmap Par1 $ decodeMessage fieldNumber
   genericLiftDotProto dotProto _ = dotProto Proxy
 
+instance (KnownNat (GenericFieldCount1 f), GenericMessage1 f) => GenericMessage1 (Rec1 f) where
+  type GenericFieldCount1 (Rec1 f) = GenericFieldCount1 f
+  genericLiftEncodeMessage encodeMessage fieldNumber (Rec1 x) = genericLiftEncodeMessage encodeMessage fieldNumber x
+  genericLiftDecodeMessage decodeMessage fieldNumber = fmap Rec1 $ genericLiftDecodeMessage decodeMessage fieldNumber
+  genericLiftDotProto dotProto _ = dotProto Proxy
+
 instance (KnownNat (GenericFieldCount1 f), GenericMessage1 f, GenericMessage1 g) => GenericMessage1 (f :*: g) where
   type GenericFieldCount1 (f :*: g) = GenericFieldCount1 f + GenericFieldCount1 g
   genericLiftEncodeMessage encodeMessage num (x :*: y) = genericLiftEncodeMessage  encodeMessage num x <> genericLiftEncodeMessage encodeMessage (FieldNumber (getFieldNumber num + offset)) y

--- a/src/Proto3/Suite/Class.hs
+++ b/src/Proto3/Suite/Class.hs
@@ -86,6 +86,7 @@ module Proto3.Suite.Class
   , Named(..)
   , Finite(..)
   , message
+  , message1
   , Proto3.Suite.Class.enum
 
   -- * Generic Classes
@@ -661,8 +662,8 @@ class Message1 f where
 message :: (Message a, Named a) => Proxy a -> DotProtoDefinition
 message pr = DotProtoMessage (Single $ nameOf pr) (dotProto pr)
 
-message1 :: (Message1 f, Named a, Message a) => Proxy (f a) -> DotProtoDefinition
-message1 pr = DotProtoMessage (Single $ nameOf (Proxy :: Proxy a)) (liftDotProto dotProto pr)
+message1 :: (Named (f a), Named a, Message1 f, Message a) => Proxy (f a) -> DotProtoDefinition
+message1 pr = DotProtoMessage (Single $ nameOf pr) (liftDotProto dotProto pr)
 
 -- * Generic Instances
 

--- a/src/Proto3/Suite/Class.hs
+++ b/src/Proto3/Suite/Class.hs
@@ -652,9 +652,10 @@ class Message1 f where
   default liftDecodeMessage :: (Generic1 f, GenericMessage1 (Rep1 f)) => (FieldNumber -> Parser RawMessage a) -> FieldNumber -> Parser RawMessage (f a)
   liftDecodeMessage decodeMessage fieldNumber = fmap to1 $ genericLiftDecodeMessage decodeMessage fieldNumber
 
-  liftDotProto :: (Proxy a -> [DotProtoMessagePart]) -> Proxy f -> [DotProtoMessagePart]
-  default liftDotProto :: GenericMessage1 (Rep1 f) => (Proxy a -> [DotProtoMessagePart]) -> Proxy f -> [DotProtoMessagePart]
-  liftDotProto dotProto _ = genericLiftDotProto dotProto (Proxy @(Rep1 f))
+  -- TODO: Take Proxy (f a) instead of Proxy f to pattern match on a
+  liftDotProto :: (Proxy a -> [DotProtoMessagePart]) -> Proxy (f a) -> [DotProtoMessagePart]
+  default liftDotProto :: forall a. GenericMessage1 (Rep1 f) => (Proxy a -> [DotProtoMessagePart]) -> Proxy (f a) -> [DotProtoMessagePart]
+  liftDotProto dotProto _ = genericLiftDotProto dotProto (Proxy @(Rep1 f a))
 
 
 -- | Generate metadata for a message type.

--- a/src/Proto3/Suite/Class.hs
+++ b/src/Proto3/Suite/Class.hs
@@ -657,11 +657,6 @@ class Message1 f where
   default liftDotProto :: forall a. GenericMessage1 (Rep1 f) => (Proxy a -> [DotProtoMessagePart]) -> Proxy (f a) -> [DotProtoMessagePart]
   liftDotProto dotProto _ = genericLiftDotProto dotProto (Proxy @(Rep1 f a))
 
--- instance Message1 [] where
---   liftEncodeMessage encodeMessage fieldNumber = foldMap (encodeMessage fieldNumber)
---   liftDecodeMessage decodeMessage fieldNumber = fmap toList $ repeated (decodeMessage fieldNumber)
---   liftDotProto dotProto _ = [ DotProtoMessageDefinition (DotProtoMessage (Single "list") (dotProto _)) ]
-
 -- | Generate metadata for a message type.
 message :: (Message a, Named a) => Proxy a -> DotProtoDefinition
 message pr = DotProtoMessage (Single $ nameOf pr) (dotProto pr)

--- a/src/Proto3/Suite/Class.hs
+++ b/src/Proto3/Suite/Class.hs
@@ -82,6 +82,7 @@ module Proto3.Suite.Class
   , fromB64
 
   -- * Documentation
+  , GenericNamed(..)
   , Named(..)
   , Finite(..)
   , message
@@ -242,6 +243,10 @@ class GenericNamed (f :: * -> *) where
 
 instance Datatype d => GenericNamed (M1 D d f) where
   genericNameOf _ = fromString (datatypeName (undefined :: M1 D d f ()))
+
+instance {-# OVERLAPS #-} (Generic1 f, Rep1 f ~ D1 c f, Datatype c) => GenericNamed f where
+  genericNameOf _ = fromString (datatypeName (undefined :: t c f a))
+
 
 -- | Enumerable types with finitely many values.
 --

--- a/src/Proto3/Suite/Class.hs
+++ b/src/Proto3/Suite/Class.hs
@@ -245,7 +245,7 @@ class GenericNamed (f :: * -> *) where
 instance Datatype d => GenericNamed (M1 D d f) where
   genericNameOf _ = fromString (datatypeName (undefined :: M1 D d f ()))
 
-instance {-# OVERLAPS #-} (Generic1 f, Rep1 f ~ D1 c f, Datatype c) => GenericNamed f where
+instance {-# OVERLAPS #-} (Generic1 f, Rep1 f ~ D1 c f', Datatype c) => GenericNamed f where
   genericNameOf _ = fromString (datatypeName (undefined :: t c f a))
 
 

--- a/src/Proto3/Suite/Class.hs
+++ b/src/Proto3/Suite/Class.hs
@@ -627,7 +627,7 @@ class Message1 f where
   default liftDecodeMessage :: (Generic1 f, GenericMessage1 (Rep1 f)) => (FieldNumber -> Parser RawMessage a) -> FieldNumber -> Parser RawMessage (f a)
   liftDecodeMessage decodeMessage fieldNumber = fmap to1 $ genericLiftDecodeMessage decodeMessage fieldNumber
 
-  liftDotProto :: (Proxy (a :: *) -> [DotProtoMessagePart]) -> Proxy f -> [DotProtoMessagePart]
+  liftDotProto :: (Proxy a -> [DotProtoMessagePart]) -> Proxy f -> [DotProtoMessagePart]
   default liftDotProto :: GenericMessage1 (Rep1 f) => (Proxy a -> [DotProtoMessagePart]) -> Proxy f -> [DotProtoMessagePart]
   liftDotProto dotProto _ = genericLiftDotProto dotProto (Proxy @(Rep1 f))
 

--- a/src/Proto3/Suite/Class.hs
+++ b/src/Proto3/Suite/Class.hs
@@ -465,7 +465,6 @@ instance MessageField T.Text
 instance MessageField TL.Text
 instance MessageField B.ByteString
 instance MessageField BL.ByteString
-instance Primitive a => MessageField (Maybe a)
 instance (Bounded e, Named e, Enum e) => MessageField (Enumerated e)
 
 instance (HasDefault a, Primitive a) => MessageField (ForceEmit a) where
@@ -473,6 +472,11 @@ instance (HasDefault a, Primitive a) => MessageField (ForceEmit a) where
 
 seqToVec :: Seq a -> Vector a
 seqToVec = fromList . F.toList
+
+instance (Named a, Message a) => MessageField (Maybe a) where
+  encodeMessageField num = foldMap (Encode.embedded num . encodeMessage (fieldNumber 1))
+  decodeMessageField = (Decode.embedded (decodeMessage (fieldNumber 1)))
+  protoType _ = messageField (Prim $ Named (Single (nameOf (Proxy @a)))) Nothing
 
 instance (Named a, Message a) => MessageField (Nested a) where
   encodeMessageField num = foldMap (Encode.embedded num . encodeMessage (fieldNumber 1)) . nested

--- a/src/Proto3/Suite/Class.hs
+++ b/src/Proto3/Suite/Class.hs
@@ -627,8 +627,8 @@ class Message1 f where
   default liftDecodeMessage :: (Generic1 f, GenericMessage1 (Rep1 f)) => (FieldNumber -> Parser RawMessage a) -> FieldNumber -> Parser RawMessage (f a)
   liftDecodeMessage decodeMessage fieldNumber = fmap to1 $ genericLiftDecodeMessage decodeMessage fieldNumber
 
-  liftDotProto :: (Proxy a -> [DotProtoField]) -> Proxy (f a) -> [DotProtoField]
-  default liftDotProto :: GenericMessage1 (Rep1 f) => (Proxy a -> [DotProtoField]) -> Proxy (f a) -> [DotProtoField]
+  liftDotProto :: (Proxy a -> [DotProtoField]) -> Proxy f -> [DotProtoField]
+  default liftDotProto :: GenericMessage1 (Rep1 f) => (Proxy a -> [DotProtoField]) -> Proxy f -> [DotProtoField]
   liftDotProto dotProto _ = genericLiftDotProto dotProto (Proxy @(Rep1 f))
 
 

--- a/src/Proto3/Suite/Class.hs
+++ b/src/Proto3/Suite/Class.hs
@@ -661,13 +661,11 @@ instance GenericMessage1 f => GenericMessage1 (M1 C c f) where
   genericLiftEncodeMessage encodeMessage fieldNumber (M1 x) = genericLiftEncodeMessage encodeMessage fieldNumber x
   genericLiftDecodeMessage decodeMessage fieldNumber = fmap M1 $ genericLiftDecodeMessage decodeMessage fieldNumber
   genericLiftDotProto dotProto _ = genericLiftDotProto dotProto (Proxy @f)
-  -- genericDecodeMessage _ _ _ =  _
 
 instance (Selector s, GenericMessage1 f) => GenericMessage1 (M1 S s f) where
   type GenericFieldCount1 (M1 S s f) = GenericFieldCount1 f
   genericLiftEncodeMessage encodeMessage fieldNumber (M1 x) = genericLiftEncodeMessage encodeMessage fieldNumber x
   genericLiftDecodeMessage decodeMessage fieldNumber = fmap M1 $ genericLiftDecodeMessage decodeMessage fieldNumber
-  -- genericDecodeMessage num = fmap M1 $ genericDecodeMessage num
   genericLiftDotProto dotProto _ = map applyName $ genericLiftDotProto dotProto (Proxy @f)
     where
       applyName :: DotProtoField -> DotProtoField

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-7.4
+resolver: lts-11.0
 
 packages:
 - .
@@ -7,13 +7,12 @@ packages:
     commit: a938330bf794cf3fa05591d03906915df98d157c
   extra-dep: true
 
-extra-deps: [ aeson-1.2.4.0
-            , aeson-pretty-0.8.5
+extra-deps: [ aeson-pretty-0.8.5
             , cabal-doctest-1.0.2
             , insert-ordered-containers-0.2.1.0
             , neat-interpolation-0.3.2.1
-            , optparse-applicative-0.13.2.0
-            , optparse-generic-1.2.1
+            , optparse-applicative-0.14.2.0
+            , optparse-generic-1.3.0
             , swagger2-2.1.6
-            , turtle-1.3.6
+            , aeson-1.3.1.1
             ]


### PR DESCRIPTION
Adds a `Message1`, `GenericMessage1`, and `MessageField1` class in order to derive message instances for types of kind `* -> *`.

Also changes `dotProto` to return a list of `[DotProtoMessagePart]` instead of `[DotProtoMessageField]` so we can construct instances that produce `oneof` protobuf declarations.