### PR TITLE
Generate updates

### DIFF
--- a/src/Proto3/Suite/Class.hs
+++ b/src/Proto3/Suite/Class.hs
@@ -66,7 +66,6 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE TypeOperators              #-}
 {-# LANGUAGE UndecidableInstances       #-}
-{-# LANGUAGE ConstrainedClassMethods    #-}
 
 module Proto3.Suite.Class
   ( Primitive(..)
@@ -264,9 +263,6 @@ class GenericNamed1 (f :: * -> *) where
 
 instance Datatype d => GenericNamed1 (M1 D d f) where
   genericNameOf1 _ = fromString (datatypeName (undefined :: M1 D d f ()))
---
--- instance (Generic1 f, Rep1 f ~ D1 c f, Datatype c) => GenericNamed1 f where
---   genericNameOf1 _ = fromString (datatypeName (undefined :: t c f a))
 
 -- | Enumerable types with finitely many values.
 --
@@ -449,7 +445,7 @@ instance (Primitive a) => Primitive (ForceEmit a) where
   decodePrimitive     = fmap ForceEmit decodePrimitive
   primType _          = primType (Proxy @a)
 
-instance (MessageField1 f) => GenericMessage1 (Rec1 f) where
+instance MessageField1 f => GenericMessage1 (Rec1 f) where
   type GenericFieldCount1 (Rec1 f) = 1
   genericLiftEncodeMessage encodeMessage fieldNumber (Rec1 x) = liftEncodeMessageField encodeMessage fieldNumber x
   genericLiftDecodeMessage decodeMessage fieldNumber = fmap Rec1 $ at (liftDecodeMessageField decodeMessage) fieldNumber
@@ -715,7 +711,7 @@ instance GenericMessage1 U1 where
   genericLiftDecodeMessage _ _ = pure U1
   genericLiftDotProto _      = mempty
 
-instance (GenericMessage1 f) => GenericMessage1 (M1 D c f) where
+instance GenericMessage1 f => GenericMessage1 (M1 D c f) where
   type GenericFieldCount1 (M1 D c f) = GenericFieldCount1 f
   genericLiftEncodeMessage encodeMessage fieldNumber (M1 x) = genericLiftEncodeMessage encodeMessage fieldNumber x
   genericLiftDecodeMessage decodeMessage fieldNumber = fmap M1 $ genericLiftDecodeMessage decodeMessage fieldNumber

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -653,10 +653,10 @@ messageInstD ctxt parentIdent msgIdent messageParts =
 
      dotProtoE <- HsList <$> sequence
          [ dpTypeE dpType >>= \typeE ->
-             pure (apply dotProtoFieldC [ fieldNumberE fieldNum, typeE
+             pure . apply dotProtoMessageFieldC . pure $ apply dotProtoFieldC [ fieldNumberE fieldNum, typeE
                                         , dpIdentE fieldIdent
                                         , HsList (map optionE options)
-                                        , maybeE (HsLit . HsString) comments ])
+                                        , maybeE (HsLit . HsString) comments ]
          | DotProtoMessageField (DotProtoField fieldNum dpType fieldIdent options comments)
              <- messageParts ]
 
@@ -1260,6 +1260,7 @@ dotProtoFieldC, primC, optionalC, repeatedC, nestedRepeatedC, namedC,
   convertServerHandlerE, convertServerReaderHandlerE, convertServerWriterHandlerE,
   convertServerRWHandlerE, clientRegisterMethodE, clientRequestE :: HsExp
 
+dotProtoMessageFieldC       = HsVar (protobufName "DotProtoMessageField")
 dotProtoFieldC       = HsVar (protobufName "DotProtoField")
 primC                = HsVar (protobufName "Prim")
 optionalC            = HsVar (protobufName "Optional")

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -1517,7 +1517,7 @@ haskellNS = Module "Hs"
 
 defaultMessageDeriving, defaultEnumDeriving, defaultServiceDeriving :: [HsQName]
 defaultMessageDeriving = map haskellName [ "Show"
-                                         , "Eq",   "Ord"
+                                         , "Eq"
                                          , "Generic" ]
 
 defaultEnumDeriving = map haskellName [ "Show", "Bounded"

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -573,13 +573,13 @@ dotProtoMessageD ctxt parentIdent messageIdent message =
        pure $ [ dataDecl_ messageName [ conDecl ] defaultMessageDeriving
               , namedInstD messageName
               , messageInst
-              , toJSONPBInst
-              , fromJSONPBInst
+              -- , toJSONPBInst
+              -- , fromJSONPBInst
                 -- Generate Aeson instances in terms of JSONPB instances
-              , toJSONInstDecl messageName
-              , fromJSONInstDecl messageName
+              -- , toJSONInstDecl messageName
+              -- , fromJSONInstDecl messageName
               -- And the Swagger ToSchema instance corresponding to JSONPB encodings
-              , toSchemaInstDecl messageName
+              -- , toSchemaInstDecl messageName
               ]
               <> nestedOneofs_
               <> nestedDecls_

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -573,13 +573,6 @@ dotProtoMessageD ctxt parentIdent messageIdent message =
        pure $ [ dataDecl_ messageName [ conDecl ] defaultMessageDeriving
               , namedInstD messageName
               , messageInst
-              -- , toJSONPBInst
-              -- , fromJSONPBInst
-                -- Generate Aeson instances in terms of JSONPB instances
-              -- , toJSONInstDecl messageName
-              -- , fromJSONInstDecl messageName
-              -- And the Swagger ToSchema instance corresponding to JSONPB encodings
-              -- , toSchemaInstDecl messageName
               ]
               <> nestedOneofs_
               <> nestedDecls_

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,7 +4,7 @@ packages:
 - .
 - location:
     git: https://github.com/joshvera/proto3-wire.git
-    commit: 4621daf8798173c96b859aa2bb7e598947f88fb3
+    commit: c8792bc33154e849239b1c91ffe06af2e765d734
   extra-dep: true
 
 extra-deps: [ aeson-pretty-0.8.5


### PR DESCRIPTION
- [x] Disable generation of `Ord` instances since fields of protobuf definitions don't need `Ord`.
- [x] Disable code generation of `JSONPB` instances since that means fields of protobuf definitions must also have JSONPB instances. It's also not possible to derive JSONPB instances at the moment.
- [x] Generate `DotProtoMessagePart` values in `dotProto` instances since the `Message` typeclass has changed.
