### PR TITLE
Fix dodgy import

### DIFF
--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -1471,8 +1471,7 @@ defaultImports usesGrpc =
   if usesGrpc
     then [ importDecl_ networkGrpcHighLevelGeneratedM   False (Just grpcNS) Nothing
          , importDecl_ networkGrpcHighLevelClientM      False (Just grpcNS) Nothing
-         , importDecl_ networkGrpcHighLevelServerM      False (Just grpcNS)
-               (Just (True, [ importSym "asyncServerLoop" ]))
+         , importDecl_ networkGrpcHighLevelServerM      False (Just grpcNS) Nothing
          , importDecl_ networkGrpcHighLevelServerUnregM False (Just grpcNS)
                (Just (False, [ importSym "asyncServerLoop" ]))
          , importDecl_ networkGrpcLowLevelCallM         False (Just grpcNS) Nothing  ]


### PR DESCRIPTION
Fix a dodgy import the `Generate` module had been generating. Previously it had been hiding the `serverLoop` function from `Network.Grpc.HighLevelServer` but it's no longer needed now that we default to `asyncServerLoop`.