### PR TITLE
Bump dependency bounds for GHC 8.6.

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -24,7 +24,7 @@ library
   other-modules:       Proto3.Suite.DotProto.Internal
                        Proto3.Suite.DotProto.Generate.Swagger
                        Proto3.Suite.JSONPB.Class
-  build-depends:       aeson >= 1.3 && < 1.4,
+  build-depends:       aeson >= 1.3 && < 1.5,
                        aeson-pretty,
                        attoparsec >= 0.13.0.1,
                        base >=4.8 && <5.0,
@@ -32,7 +32,7 @@ library
                        bytestring >=0.10.6.0 && <0.11.0,
                        deepseq ==1.4.*,
                        cereal >= 0.5.1 && <0.6,
-                       containers ==0.5.*,
+                       containers >= 0.5 && <0.7,
                        foldl,
                        haskell-src ==1.0.*,
                        lens,
@@ -41,19 +41,19 @@ library
                        parsec >= 3.1.9 && <3.2.0,
                        parsers >= 0.12 && <0.13,
                        pretty ==1.1.*,
-                       pretty-show >= 1.6.12 && < 1.8,
+                       pretty-show >= 1.6.12 && < 1.9,
                        proto3-wire == 1.0.*,
                        QuickCheck >=2.8 && <3.0,
                        quickcheck-instances >= 0.3.16.1 && <0.4,
                        safe ==0.3.*,
                        semigroups ==0.18.*,
-                       swagger2 >= 2.1.6 && < 2.3,
+                       swagger2 >= 2.1.6 && < 2.4,
                        system-filepath,
                        text >= 0.2 && <1.3,
                        transformers >=0.4 && <0.6,
                        turtle,
                        vector >=0.11 && < 0.13,
-                       wl-pprint,
+                       wl-pprint == 1.2.*,
                        ghc-typelits-extra
 
   hs-source-dirs:      src
@@ -104,7 +104,7 @@ executable canonicalize-proto-file
   hs-source-dirs:      tools/canonicalize-proto-file
   default-language:    Haskell2010
   build-depends:       base >=4.8 && <5.0
-                       , containers ==0.5.*
+                       , containers >= 0.5 && <0.7
                        , optparse-generic
                        , proto3-suite
                        , proto3-wire == 1.0.*


### PR DESCRIPTION
Tested with the latest Stackage nightly. Works fine.