### PR TITLE
Switch from wl-pprint to ansi-wl-pprint.

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -26,6 +26,7 @@ library
                        Proto3.Suite.JSONPB.Class
   build-depends:       aeson >= 1.3 && < 1.5,
                        aeson-pretty,
+                       ansi-wl-pprint >= 0.6 && <1,
                        attoparsec >= 0.13.0.1,
                        base >=4.8 && <5.0,
                        base64-bytestring >= 1.0.0.1 && < 1.1,
@@ -53,7 +54,6 @@ library
                        transformers >=0.4 && <0.6,
                        turtle,
                        vector >=0.11 && < 0.13,
-                       wl-pprint == 1.2.*,
                        ghc-typelits-extra
 
   hs-source-dirs:      src

--- a/src/Proto3/Suite/DotProto/Rendering.hs
+++ b/src/Proto3/Suite/DotProto/Rendering.hs
@@ -22,12 +22,12 @@ module Proto3.Suite.DotProto.Rendering
 import Prelude hiding ((<>))
 
 import           Data.Char
-import qualified Data.Text                 as T
-import           Filesystem.Path.CurrentOS (toText)
+import qualified Data.Text                    as T
+import           Filesystem.Path.CurrentOS    (toText)
 import           Proto3.Suite.DotProto.AST
-import           Proto3.Wire.Types         (FieldNumber (..))
-import           Text.PrettyPrint.Leijen   ((<$$>), (<+>), (<>), Pretty(..))
-import qualified Text.PrettyPrint.Leijen   as PP
+import           Proto3.Wire.Types            (FieldNumber (..))
+import           Text.PrettyPrint.ANSI.Leijen ((<$$>), (<+>), (<>), Pretty(..))
+import qualified Text.PrettyPrint.ANSI.Leijen as PP
 
 -- | Options for rendering a @.proto@ file.
 data RenderingOptions = RenderingOptions


### PR DESCRIPTION
`wl-pprint` is unmaintained and not present in any Stackage releases,
so it entails additional `extra-dep` fields in packages that depend
on this. `ansi-wl-pprint` is API-compatible and produces identical output.

This will save us an extra dependency downstream.