### PR TITLE
Add convenience functions and patterns.

### DIFF
--- a/src/Proto3/Suite.hs
+++ b/src/Proto3/Suite.hs
@@ -18,15 +18,17 @@
 module Proto3.Suite
   (
   -- * Message Encoding/Decoding
-    toLazyByteString
-  , fromByteString
+    toByteString
+  , toLazyByteString
   , toLazyByteString1
+  , fromByteString
   , fromByteString1
   , fromB64
   , Message(..)
   , Message1(..)
   , MessageField(..)
   , Primitive(..)
+  , PrimitiveEnum(..)
   , HasDefault(..)
   , FieldNumber(..)
   , fieldNumber

--- a/src/Proto3/Suite/Types.hs
+++ b/src/Proto3/Suite/Types.hs
@@ -9,7 +9,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Proto3.Suite.Types
   (

--- a/src/Proto3/Suite/Types.hs
+++ b/src/Proto3/Suite/Types.hs
@@ -59,7 +59,7 @@ instance (Bounded a, Enum a) => Arbitrary (Enumerated a) where
     i <- arbitrary
     if i < fromEnum (minBound :: a) || i > fromEnum (maxBound :: a)
        then return $ Enumerated $ Left i
-       else return $ Enumerated $ Right (toEnum i)  
+       else return $ Enumerated $ Right (toEnum i)
 
 -- | 'PackedVec' provides a way to encode packed lists of basic protobuf types into
 -- the wire format.

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,8 +1,8 @@
-resolver: lts-12.0
+resolver: lts-13.1
 
 packages:
 - .
 - location:
     git: https://github.com/joshvera/proto3-wire.git
-    commit: 9a287602218668aefceede406c93232fc0890f33
+    commit: 84664e22f01beb67870368f1f88ada5d0ad01f56
   extra-dep: true


### PR DESCRIPTION
This patch backports three changes from elsewhere that make life easier
for consumers of this library:

* `Present` and `Absent` pattern synonyms for matching and
  constructing `Nested` values, providing a measure of syntactic
  convenience while still avoiding `Maybe`-blindness.
* The `PrimitiveEnum` newtype to make writing instances of `Primitive`
  for enumerated types easy with `-XDerivingVia`.
* A `toByteString` combinator to complement `toLazyByteString`.

This also fixes the stack.yaml so that it compiles with LTS 13.