### PR TITLE
Conditional space for streaming keyword

### DIFF
--- a/src/Proto3/Suite/DotProto/Rendering.hs
+++ b/src/Proto3/Suite/DotProto/Rendering.hs
@@ -156,9 +156,9 @@ instance Pretty DotProtoServicePart where
   pretty (DotProtoServiceRPC name (callname, callstrm) (retname, retstrm) options)
     =   PP.text "rpc"
     <+> pretty name
-    <+> PP.parens (pretty callstrm <+> pretty callname)
+    <+> PP.parens (pretty callstrm <> pretty callname)
     <+> PP.text "returns"
-    <+> PP.parens (pretty retstrm <+> pretty retname)
+    <+> PP.parens (pretty retstrm <> pretty retname)
     <>  case options of
           [] -> PP.semi
           _  -> PP.space <> (PP.braces . PP.vcat $ topOption <$> options)
@@ -166,7 +166,7 @@ instance Pretty DotProtoServicePart where
   pretty DotProtoServiceEmpty           = PP.empty
 
 instance Pretty Streaming where
-  pretty Streaming    = PP.text "stream"
+  pretty Streaming    = PP.text "stream" <> PP.space
   pretty NonStreaming = PP.empty
 
 instance Pretty DotProtoIdentifier where


### PR DESCRIPTION
Allows generating `rpc` service description that are formatted without extraneous space.

``` diff
- rpc Ping ( PingRequest) returns ( PingResponse);
+ rpc Ping (PingRequest) returns (PingResponse);
```

cc @joshvera 